### PR TITLE
FFmpeg: Fix build errors with FFmpeg5

### DIFF
--- a/container/container_ffmpeg.c
+++ b/container/container_ffmpeg.c
@@ -1853,7 +1853,8 @@ int32_t container_ffmpeg_init_av_context(Context_t *context, char *filename, uin
         }
     }
 
-    avContextTab[AVIdx]->iformat->flags |= AVFMT_SEEK_TO_PTS;
+    //ffmpeg5: error: assignment of member 'flags' in read-only object -> so commented out next line
+	//avContextTab[AVIdx]->iformat->flags |= AVFMT_SEEK_TO_PTS;
     avContextTab[AVIdx]->flags = AVFMT_FLAG_GENPTS;
 
     if (context->playback->noprobe)
@@ -2268,7 +2269,7 @@ int32_t container_ffmpeg_update_tracks(Context_t *context, char *filename, int32
                         {
                             ffmpeg_printf(10, " Handle inject_as_pcm = %d\n", track.inject_as_pcm);
 
-                            AVCodec *codec = avcodec_find_decoder(get_codecpar(stream)->codec_id);
+                            const AVCodec *codec = avcodec_find_decoder(get_codecpar(stream)->codec_id);
 
                             int errorCode = avcodec_open2(track.avCodecCtx, codec, NULL);
                             if(codec != NULL && !errorCode)

--- a/container/mpeg4p2_ffmpeg.c
+++ b/container/mpeg4p2_ffmpeg.c
@@ -4,6 +4,8 @@
 //
 
 // mpeg4_unpack_bframes
+#include <libavcodec/bsf.h>
+
 typedef struct
 {
     const AVBitStreamFilter *bsf;

--- a/container/wrapped_ffmpeg.c
+++ b/container/wrapped_ffmpeg.c
@@ -3,6 +3,8 @@
  * allows to compile and use exteplayer3 
  * with old ffmpeg libs
  */
+#include <libavcodec/avcodec.h>
+
 static void wrapped_frame_free(void *param)
 {
 #if (LIBAVCODEC_VERSION_MAJOR >= 55)

--- a/output/graphic_subtitle.c
+++ b/output/graphic_subtitle.c
@@ -234,14 +234,14 @@ static int32_t Write(WriterSubCallData_t *subPacket)
     AVSubtitle subtitle;
     memset(&subtitle, 0, sizeof(subtitle));
 
-    AVPacket pkt;
-    av_init_packet(&pkt);
-    pkt.data = subPacket->data;
-    pkt.size = subPacket->len;
-    pkt.pts  = subPacket->pts;
+    AVPacket* pkt;
+	pkt = av_packet_alloc();
+    pkt->data = subPacket->data;
+    pkt->size = subPacket->len;
+    pkt->pts  = subPacket->pts;
 
     int has_subtitle = 0;
-    int used = avcodec_decode_subtitle2(g_sys->p_context, &subtitle, &has_subtitle, &pkt);
+    int used = avcodec_decode_subtitle2(g_sys->p_context, &subtitle, &has_subtitle, pkt);
     uint32_t width = g_sys->p_context->width > 0 ? g_sys->p_context->width : subPacket->width;
     uint32_t height = g_sys->p_context->height > 0 ? g_sys->p_context->height : subPacket->height;
     if (has_subtitle && width > 0 && height > 0)

--- a/output/graphic_subtitle.c
+++ b/output/graphic_subtitle.c
@@ -235,7 +235,7 @@ static int32_t Write(WriterSubCallData_t *subPacket)
     memset(&subtitle, 0, sizeof(subtitle));
 
     AVPacket* pkt;
-	pkt = av_packet_alloc();
+    pkt = av_packet_alloc();
     pkt->data = subPacket->data;
     pkt->size = subPacket->len;
     pkt->pts  = subPacket->pts;


### PR DESCRIPTION
- container\container_ffmpeg.c: comment out read-only object member assignment and use const for AVCodec
- container\mpeg4p2_ffmpeg.c: add missing include of bsf.h
- container\wrapped_ffmpeg.c: add missing include of avcodec.h
- output\graphic_subtitle.c: replace deprecated av_init_packet API, see https://github.com/kaltura/nginx-vod-module/pull/1284/files